### PR TITLE
initial news articles setup for latest news

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~8.2.14",
+    "@angular/animations": "^8.2.14",
     "@angular/cdk": "^8.2.3",
     "@angular/cli": "~8.3.19",
     "@angular/common": "~8.2.14",

--- a/src/app/components/latest-news/latest-news.component.html
+++ b/src/app/components/latest-news/latest-news.component.html
@@ -1,1 +1,32 @@
-<p>latest-news works!</p>
+<span>News Headlines</span> 
+<mat-list class="list-nav">
+    <mat-list-item class="list-item" *ngFor="let source of mSources" (click)="searchArticles(source.id)">
+
+      <div mat-card-avatar [ngStyle]="{'background-image': 'url(../assets/images/'+ source.id +'.png)'}" class="example-header-image"></div>
+
+      <span class="source-name"> {{source.name}}</span>
+
+      
+
+    </mat-list-item>
+</mat-list>
+
+<mat-card class="example-card"  *ngFor="let article of mArticles">
+    <mat-card-header>
+      <div mat-card-avatar [ngStyle]="{'background-image': 'url(../assets/images/'+ article.source.id +'.png)'}" class="example-header-image"></div>
+      <mat-card-title class="title">{{article.title}}</mat-card-title>
+      <mat-card-subtitle>{{article.source.name}}</mat-card-subtitle>
+    </mat-card-header>
+    <img mat-card-image class="img-article" src={{article.urlToImage}} alt="">
+    <mat-card-content>
+      <p>
+        {{article.description}}
+      </p>
+    </mat-card-content>
+    <mat-card-actions class="action-buttons">
+      <button mat-button color="primary"><mat-icon>thumb_up_alt</mat-icon> 12 Likes</button>
+      <button mat-button color="primary"><mat-icon>comment</mat-icon> Comments</button>
+      <button mat-button color="primary"><mat-icon>share</mat-icon> Share</button>
+      <a mat-button color="primary" href={{article.url}} target="_blank" ><mat-icon>visibility</mat-icon> More</a>
+    </mat-card-actions>
+  </mat-card>

--- a/src/app/components/latest-news/latest-news.component.ts
+++ b/src/app/components/latest-news/latest-news.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { NewsApiService } from 'src/app/services/news-api.service';
+
 
 @Component({
   selector: 'app-latest-news',
@@ -7,9 +9,23 @@ import { Component, OnInit } from '@angular/core';
 })
 export class LatestNewsComponent implements OnInit {
 
-  constructor() { }
+  mArticles:Array<any>;
+  mSources:Array<any>;
+
+  constructor(private newsapi:NewsApiService) {
+    console.log('component constructor called');
+   }
 
   ngOnInit() {
+    //load articles
+    this.newsapi.initArticles().subscribe(data => this.mArticles = data['articles']);
+    //load news sources
+    this.newsapi.initSources().subscribe(data => this.mSources = data['sources']);
+  }
+
+  searchArticles(source) {
+    console.log("selected source is: " + source);
+    this.newsapi.getArticlesByID(source).subscribe(data => this.mArticles = data['articles']);
   }
 
 }

--- a/src/app/components/side-nav/side-nav.component.html
+++ b/src/app/components/side-nav/side-nav.component.html
@@ -18,7 +18,7 @@
              </mat-list-item>
              <mat-list-item>
                  <a matLine [routerLink]="['/latest-news']">
-                 <mat-icon>paper</mat-icon> Latest News</a>
+                 <mat-icon>box</mat-icon> Latest News</a>
              </mat-list-item>
             
           </mat-nav-list>

--- a/src/app/services/news-api.service.spec.ts
+++ b/src/app/services/news-api.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NewsApiService } from './news-api.service';
+
+describe('NewsApiService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: NewsApiService = TestBed.get(NewsApiService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/news-api.service.ts
+++ b/src/app/services/news-api.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient  } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NewsApiService {
+
+  api_key = 'fb91ed73ca334daa86cb03d3af7d83a1';
+
+  constructor(private http:HttpClient) { }
+
+  initSources(){
+    return this.http.get('https://newsapi.org/v2/sources?language=en&apiKey='+this.api_key);
+  }
+
+  initArticles(){
+    return this.http.get('https://newsapi.org/v2/top-headlines?sources=techcrunch&apiKey='+this.api_key);
+   }
+
+   getArticlesByID(source: String) {
+     return this.http.get('https://newsapi.org/v2/top-headlines?sources='+source+'&apiKey='+this.api_key);
+   }
+}


### PR DESCRIPTION
setup initial http request to newsapi.org using their free API key. Articles and news sources are rendered in the latest news template for now. TODOs: setup news sources in side nav menu to communicate with latest news template. As well, the news articles need to be specific to covid 19